### PR TITLE
ADD: Ability to set cloudflare configs in API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ POST /certificate_request
 	"auth_token": "CHOSEN AUTH TOKEN",
 	"domains": ["www.substrakt.com", "substrakt.com"],
 	"zone": "CLOUDFLARE DOMAIN ZONE",
-	"heroku_app_name": "NAME OF HEROKU APP"
+	"heroku_app_name": "NAME OF HEROKU APP",
+	"cloudflare_api_key": "API KEY OF CLOUDFLARE ACCOUNT",
+	"cloudflare_email": "CLOUDFLARE EMAIL ADDRESS"
 }
 ```
 

--- a/app.json
+++ b/app.json
@@ -8,12 +8,6 @@
   "website": "https://substrakt.com/",
   "repository": "https://github.com/substrakt/letsencrypt-heroku",
   "env": {
-    "CLOUDFLARE_API_KEY": {
-      "description": "Your CloudFlare API Key."
-    },
-    "CLOUDFLARE_EMAIL": {
-      "description": "The email address for your CloudFlare account."
-    },
     "HEROKU_OAUTH_KEY": {
       "description": "A valid OAuth key to access your Heroku appications."
     },

--- a/lib/cloudflare_challenge.rb
+++ b/lib/cloudflare_challenge.rb
@@ -3,17 +3,11 @@ require 'cloudflare'
 
 class CloudflareChallenge
 
-  class NoCloudflareAPIKey < StandardError; end;
-  class NoCloudflareEmail < StandardError; end;
-
   attr_reader :zone, :domains, :client, :challenges, :token, :email, :api_key
 
   def initialize(options = {})
-    @email   = options[:email] || ENV['CLOUDFLARE_EMAIL']
-    @api_key = options[:api_key] || ENV['CLOUDFLARE_API_KEY']
-
-    raise NoCloudflareAPIKey if @api_key.blank?
-    raise NoCloudflareEmail  if @email.blank?
+    @email   = options[:email]
+    @api_key = options[:api_key]
 
     @zone    = options[:zone]
     @domains = options[:domains]

--- a/lib/cloudflare_challenge.rb
+++ b/lib/cloudflare_challenge.rb
@@ -6,11 +6,14 @@ class CloudflareChallenge
   class NoCloudflareAPIKey < StandardError; end;
   class NoCloudflareEmail < StandardError; end;
 
-  attr_reader :zone, :domains, :client, :challenges, :token
+  attr_reader :zone, :domains, :client, :challenges, :token, :email, :api_key
 
   def initialize(options = {})
-    raise NoCloudflareAPIKey if ENV['CLOUDFLARE_API_KEY'].blank?
-    raise NoCloudflareEmail  if ENV['CLOUDFLARE_EMAIL'].blank?
+    @email   = options[:email] || ENV['CLOUDFLARE_EMAIL']
+    @api_key = options[:api_key] || ENV['CLOUDFLARE_API_KEY']
+
+    raise NoCloudflareAPIKey if @api_key.blank?
+    raise NoCloudflareEmail  if @email.blank?
 
     @zone    = options[:zone]
     @domains = options[:domains]
@@ -22,7 +25,7 @@ class CloudflareChallenge
   end
 
   def create_challenge_records
-    cf = CloudFlare::connection(ENV['CLOUDFLARE_API_KEY'], ENV['CLOUDFLARE_EMAIL'])
+    cf = CloudFlare::connection(@api_key, @email)
     @challenges.each do |challenge|
       cf.rec_new(@zone, 'TXT', "_acme-challenge.#{challenge.domain}", challenge.dns01.record_content, 1)
     end

--- a/test/certificate_generator_test.rb
+++ b/test/certificate_generator_test.rb
@@ -3,8 +3,6 @@ require_relative 'test_helper'
 class CertificateGeneratorTest < MiniTest::Test
 
   def setup
-    ENV['CLOUDFLARE_API_KEY'] = '547348956734789576'
-    ENV['CLOUDFLARE_EMAIL']   = 'max@substrakt.com'
     ENV['CONTACT_EMAIL']      = 'max@substrakt.com'
   end
 
@@ -16,6 +14,8 @@ class CertificateGeneratorTest < MiniTest::Test
     VCR.use_cassette('new-certificate-debug') do
       a = CertificateGenerator.new(challenge: CloudflareChallenge.new(zone: 'substrakt.com',
                                                                       domains: ['www.substrakt.com', 'substrakt.com'],
+                                                                      api_key: 'fsdfdsf',
+                                                                      email: 'adam@example.com',
                                                                       client: AcmeClientRegistration.new(debug: true).client))
       assert_equal Acme::Client::Certificate, a.certificate.class
     end

--- a/test/cloudflare_challenge_test.rb
+++ b/test/cloudflare_challenge_test.rb
@@ -3,9 +3,7 @@ require_relative 'test_helper'
 class CloudflareChallengeTest < MiniTest::Test
 
   def setup
-    ENV['CLOUDFLARE_API_KEY'] = '547348956734789576'
-    ENV['CLOUDFLARE_EMAIL']   = 'max@substrakt.com'
-    ENV['CONTACT_EMAIL']      = 'max@substrakt.com'
+    ENV['CONTACT_EMAIL'] = 'max@substrakt.com'
   end
 
   def teardown
@@ -16,6 +14,8 @@ class CloudflareChallengeTest < MiniTest::Test
     VCR.use_cassette('acme-new-authz') do
       a = CloudflareChallenge.new(zone: 'substrakt.com',
                                   domains: ['www.substrakt.com', 'substrakt.com'],
+                                  api_key: 'fsdfdsf',
+                                  email: 'adam@example.com',
                                   client: AcmeClientRegistration.new(debug: true).client)
       assert_equal CloudflareChallenge, a.class
     end
@@ -35,24 +35,12 @@ class CloudflareChallengeTest < MiniTest::Test
     end
   end
 
-  def test_raise_an_exception_if_CLOUDFLARE_API_KEY_is_missing
-    ENV['CLOUDFLARE_API_KEY'] = nil
-    assert_raises CloudflareChallenge::NoCloudflareAPIKey do
-      CloudflareChallenge.new
-    end
-  end
-
-  def test_raise_an_exception_if_CLOUDFLARE_EMAIL_is_missing
-    ENV['CLOUDFLARE_EMAIL'] = nil
-    assert_raises CloudflareChallenge::NoCloudflareEmail do
-      CloudflareChallenge.new
-    end
-  end
-
   def test_set_zone
     VCR.use_cassette('acme-new-authz') do
       a = CloudflareChallenge.new(zone: 'substrakt.com',
                                   domains: ['www.substrakt.com', 'substrakt.com'],
+                                  api_key: 'fsdfdsf',
+                                  email: 'adam@example.com',
                                   client: AcmeClientRegistration.new(debug: true).client)
       assert_equal 'substrakt.com', a.zone
     end
@@ -62,6 +50,8 @@ class CloudflareChallengeTest < MiniTest::Test
     VCR.use_cassette('acme-new-authz') do
       a = CloudflareChallenge.new(zone: 'substrakt.com',
                                   domains: ['www.substrakt.com', 'substrakt.com'],
+                                  api_key: 'fsdfdsf',
+                                  email: 'adam@example.com',
                                   client: AcmeClientRegistration.new(debug: true).client)
       assert_equal ['www.substrakt.com', 'substrakt.com'], a.domains
     end
@@ -71,6 +61,8 @@ class CloudflareChallengeTest < MiniTest::Test
     VCR.use_cassette('acme-new-authz') do
       a = CloudflareChallenge.new(zone: 'substrakt.com',
                                   domains: ['www.substrakt.com', 'substrakt.com'],
+                                  api_key: 'fsdfdsf',
+                                  email: 'adam@example.com',
                                   client: AcmeClientRegistration.new(debug: true).client)
       assert_equal ['www.substrakt.com', 'substrakt.com'], a.create_challenge_records
     end
@@ -80,6 +72,8 @@ class CloudflareChallengeTest < MiniTest::Test
     VCR.use_cassette('acme-new-authz') do
       a = CloudflareChallenge.new(zone: 'substrakt.com',
                                   domains: ['www.substrakt.com', 'substrakt.com'],
+                                  api_key: 'fsdfdsf',
+                                  email: 'adam@example.com',
                                   client: AcmeClientRegistration.new(debug: true).client)
       assert_equal Challenge, a.challenges.first.class
     end
@@ -89,6 +83,8 @@ class CloudflareChallengeTest < MiniTest::Test
     VCR.use_cassette('acme-challenge-debug') do
       a = CloudflareChallenge.new(zone: 'substrakt.com',
                                   domains: ['max123.substrakt.com', 'max345.substrakt.com'],
+                                  api_key: 'fsdfdsf',
+                                  email: 'adam@example.com',
                                   client: AcmeClientRegistration.new(debug: true).client)
       assert_equal true, a.verify
     end

--- a/test/cloudflare_challenge_test.rb
+++ b/test/cloudflare_challenge_test.rb
@@ -21,6 +21,20 @@ class CloudflareChallengeTest < MiniTest::Test
     end
   end
 
+  def test_create_an_instance_with_custom_auth
+    ENV['CLOUDFLARE_EMAIL']   = nil
+    ENV['CLOUDFLARE_API_KEY'] = nil
+    VCR.use_cassette('acme-new-authz') do
+      a = CloudflareChallenge.new(zone: 'substrakt.com',
+                                  domains: ['www.substrakt.com', 'substrakt.com'],
+                                  api_key: 'fdhsufgdjshfgsd',
+                                  email: 'max@substrakt.com',
+                                  client: AcmeClientRegistration.new(debug: true).client)
+      assert_equal 'max@substrakt.com', a.email
+      assert_equal 'fdhsufgdjshfgsd', a.api_key
+    end
+  end
+
   def test_raise_an_exception_if_CLOUDFLARE_API_KEY_is_missing
     ENV['CLOUDFLARE_API_KEY'] = nil
     assert_raises CloudflareChallenge::NoCloudflareAPIKey do

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -20,6 +20,8 @@ class LoggerTest < MiniTest::Test
     VCR.use_cassette('new-certificate-debug') do
       a = CertificateGenerator.new(challenge: CloudflareChallenge.new(zone: 'substrakt.com',
                                                                       domains: ['www.substrakt.com', 'substrakt.com'],
+                                                                      api_key: 'fsdfdsf',
+                                                                      email: 'adam@example.com',
                                                                       client: AcmeClientRegistration.new(debug: true).client))
       assert_equal "[Zone: substrakt.com - Domains: www.substrakt.com, substrakt.com] ----> This is a test message", Logger.log('This is a test message', generator: a)
     end
@@ -29,6 +31,8 @@ class LoggerTest < MiniTest::Test
     VCR.use_cassette('new-certificate-debug') do
       a = CertificateGenerator.new(challenge: CloudflareChallenge.new(zone: 'substrakt.com',
                                                                       token: 'testingtesting',
+                                                                      api_key: 'fsdfdsf',
+                                                                      email: 'adam@example.com',
                                                                       domains: ['www.substrakt.com', 'substrakt.com'],
                                                                       client: AcmeClientRegistration.new(debug: true).client))
       Logger.log('Test message', generator: a)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 ENV['RACK_ENV'] = 'test'
+ENV['ENVIRONMENT'] = 'test'
 require 'minitest/autorun'
 require 'rack/test'
 require 'vcr'

--- a/workers/cloudflare_challenge_worker.rb
+++ b/workers/cloudflare_challenge_worker.rb
@@ -10,14 +10,17 @@ class CloudflareChallengeWorker
 
   sidekiq_options :retry => false
 
-  def perform(zone, domains, token, app_name, debug = true)
+  def perform(zone, domains, token, app_name, debug = true, cloudflare = {})
     $redis = Redis.new(url: ENV['REDIS_URL'])
     $redis.setex("status_#{token}", 3600, "started")
     Logger.log("Starting challenge creation on zone: #{zone}, with domains: #{domains}.")
     Logger.log("Debug is #{debug ? 'ON' : 'OFF'}")
+    puts cloudflare["email"]
     a = CloudflareChallenge.new(zone: zone,
                             domains: domains,
                             token: token,
+                            email: cloudflare["email"],
+                            api_key: cloudflare["api_key"],
                             client: AcmeClientRegistration.new(debug: debug).client)
 
     begin

--- a/workers/cloudflare_challenge_worker.rb
+++ b/workers/cloudflare_challenge_worker.rb
@@ -15,7 +15,6 @@ class CloudflareChallengeWorker
     $redis.setex("status_#{token}", 3600, "started")
     Logger.log("Starting challenge creation on zone: #{zone}, with domains: #{domains}.")
     Logger.log("Debug is #{debug ? 'ON' : 'OFF'}")
-    puts cloudflare["email"]
     a = CloudflareChallenge.new(zone: zone,
                             domains: domains,
                             token: token,


### PR DESCRIPTION
Currently, each instance of the application can only use one CF account by setting details in the environment variables.
Now you can define a cloudflare_email and cloudflare_api_key params and they will override the environment variables on each call.